### PR TITLE
针对有道变更API的提交:让广大新、老用户暂时都能用，老用户不用重新申请KEY

### DIFF
--- a/src/cn/yiiguxing/plugin/translate/Translator.java
+++ b/src/cn/yiiguxing/plugin/translate/Translator.java
@@ -109,9 +109,39 @@ public final class Translator {
                 apiKeyValue = DEFAULT_API_KEY_VALUE;
             }
         }
+				/**
+         * 2017-6-9 yangFan
+         * 改变返回逻辑，以达新、老用户都能用，老用户不用重新申请KEY的目的
+         */
+        if (isOldValue(apiKeyValue)) {
+            return BASIC_URL + "?type=data&doctype=json&version=1.1&keyfrom=" + apiKeyName + "&key=" +
+                    apiKeyValue + "&q=" + encodedQuery;
+        } else {
+            return TranslatorURLFix.getFixedQueryUrl(apiKeyName, apiKeyValue, query);
+        }
 
-        return BASIC_URL + "?type=data&doctype=json&version=1.1&keyfrom=" + apiKeyName + "&key=" +
-                apiKeyValue + "&q=" + encodedQuery;
+//        return BASIC_URL + "?type=data&doctype=json&version=1.1&keyfrom=" + apiKeyName + "&key=" +
+//                apiKeyValue + "&q=" + encodedQuery;
+    }
+
+    /**
+     * 2017-6-9 yangFan
+     * 判断是否是有道翻译旧接口的API_KEY_VALUE
+     * 依据1、旧接口value长度在10左右，新接口value长度在32左右
+     * 依据2、旧接口value是纯数字，新接口value是大小写字母与数字的混合
+     */
+    public static boolean isOldValue(String str) {
+
+        if (str.length() < 20) {
+            return true;//长度小于20的是OldValue，返回true
+        }
+        for (int i = 0; i < str.length(); i++) {
+            System.out.println(str.charAt(i));
+            if (!Character.isDigit(str.charAt(i))) {
+                return false;//非纯数字是newValue，返回false
+            }
+        }
+        return true;//纯数字是OldValue，返回true
     }
 
     private final class QueryRequest implements Runnable {

--- a/src/cn/yiiguxing/plugin/translate/TranslatorURLFix.java
+++ b/src/cn/yiiguxing/plugin/translate/TranslatorURLFix.java
@@ -1,0 +1,134 @@
+package cn.yiiguxing.plugin.translate;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 2017-6-9 yangFan
+ * 有道翻译更改了其API，需要对新用户返回一个新的URL
+ */
+public class TranslatorURLFix {
+    private static final String NEW_BASIC_URL = "https://openapi.youdao.com/api";//有道翻译新接口地址
+
+    public static String getFixedQueryUrl(String apiKeyName, String apiKeyValue, String queryStr) {
+        String appKey = apiKeyName;//key_name
+        String query = queryStr;//查询码
+        String salt = String.valueOf(System.currentTimeMillis());
+        String from = "auto";
+        String to = "auto";
+        String md5Str = appKey + query + salt + apiKeyValue;//key_value
+        String sign = md5(md5Str);
+
+        Map<String, String> params = new HashMap<String, String>();
+        params.put("q", query);
+        params.put("from", from);
+        params.put("to", to);
+        params.put("sign", sign);
+        params.put("salt", salt);
+        params.put("appKey", appKey);
+        return getUrlWithQueryString(NEW_BASIC_URL, params);
+    }
+
+    /**
+     * 生成32位MD5摘要
+     *
+     * @param string
+     * @return
+     */
+    public static String md5(String string) {
+        if (string == null) {
+            return null;
+        }
+        char hexDigits[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F'};
+        byte[] btInput = null;
+        try {
+            btInput = string.getBytes("UTF-8");
+        } catch (Exception e) {
+
+        }
+        try {
+            /** 获得MD5摘要算法的 MessageDigest 对象 */
+            MessageDigest mdInst = MessageDigest.getInstance("MD5");
+            /** 使用指定的字节更新摘要 */
+            mdInst.update(btInput);
+            /** 获得密文 */
+            byte[] md = mdInst.digest();
+            /** 把密文转换成十六进制的字符串形式 */
+            int j = md.length;
+            char str[] = new char[j * 2];
+            int k = 0;
+            for (byte byte0 : md) {
+                str[k++] = hexDigits[byte0 >>> 4 & 0xf];
+                str[k++] = hexDigits[byte0 & 0xf];
+            }
+            return new String(str);
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 根据api地址和参数生成请求URL
+     *
+     * @param url
+     * @param params
+     * @return
+     */
+    public static String getUrlWithQueryString(String url, Map<String, String> params) {
+        if (params == null) {
+            return url;
+        }
+
+        StringBuilder builder = new StringBuilder(url);
+        if (url.contains("?")) {
+            builder.append("&");
+        } else {
+            builder.append("?");
+        }
+
+        int i = 0;
+        for (String key : params.keySet()) {
+            String value = params.get(key);
+            if (value == null) { // 过滤空的key
+                continue;
+            }
+
+            if (i != 0) {
+                builder.append('&');
+            }
+
+            builder.append(key);
+            builder.append('=');
+            builder.append(encode(value));
+
+            i++;
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * 进行URL编码
+     *
+     * @param input
+     * @return
+     */
+    public static String encode(String input) {
+        if (input == null) {
+            return "";
+        }
+
+        try {
+            return URLEncoder.encode(input, "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+
+        return input;
+    }
+}


### PR DESCRIPTION
## 改动:
- Translator.getQueryUrl()对新、老用户有不同的return
- 新增类TranslatorURLFix获取新API下的URL
## 不成熟的想法:

- 引入其翻译接口时(例如谷歌翻译、百度翻译、什么翻译)，下图可能是一个思路(例如”获取最终URL“的顶层是一个通用接口)
-
![2017-06-09_231236](https://user-images.githubusercontent.com/19257125/26997011-0f41e986-4da9-11e7-8d1c-954e553c42ed.png)
*[下载地址](https://raw.githubusercontent.com/yfbdxz/TranslationFixedJar/master/TranslationPlugin.zip)注：老用户不需要重新申请KEY，新用户 Key From:填写应用ID。API Key:填写应用的密钥。暂时替代方案，作者更新后请重新下载用原来的*
