### PR TITLE
单词本txt导出

### DIFF
--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/wordbook/TxtWordBookExporter.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/wordbook/TxtWordBookExporter.kt
@@ -1,0 +1,24 @@
+package cn.yiiguxing.plugin.translate.wordbook
+
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+
+class TxtWordBookExporter : WordBookExporter {
+
+    override val name: String = "TXT"
+
+    override val extension: String = "txt"
+
+    override fun export(words: List<WordBookItem>, outputStream: OutputStream) {
+        val writer = OutputStreamWriter(outputStream, Charsets.UTF_8.name())
+        words.forEach {
+            writer.write(
+                it.word + "\t"
+                        + (if (it.phonetic.isNullOrEmpty()) "" else it.phonetic + "\t")
+                        + (it.explanation?.replace(Regex("[\n\t]"), " ")?:" ")
+                        + "\n"
+            )
+        }
+        writer.flush()
+    }
+}

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/wordbook/WordBookImportExport.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/wordbook/WordBookImportExport.kt
@@ -33,7 +33,8 @@ import com.intellij.openapi.vfs.VirtualFile
 val WORD_BOOK_EXPORTERS: List<WordBookExporter> = listOf(
     JsonWordBookExporter(),
     XmlWordBookExporter(),
-    YoudaoXmlWordBookExporter()
+    YoudaoXmlWordBookExporter(),
+    TxtWordBookExporter()
 )
 
 private const val EXTENSION_XML = "xml"


### PR DESCRIPTION
需求来源：自己常用的不背单词app支持自定义导入单词本。
本来写了impoter，不打算提交。

- 匹配 ‘hello 你好’ ，但是可能会存在单词没发音的情况。
-  单词表感觉主要的单词备份的功能，支持动态添加导入的话，需要调用查询api，导致依赖了其它模块

暂时没想到比较好 importer 方法，打了草稿，除非严格格式，感谢作者不吝赐教！

```java
class TxtWordBookImporter: WordBookImporter {
    override fun InputStream.readWords(): List<WordBookItem> {
        val reader = InputStreamReader(this)
        val words = WordBookService.getWords().map { it.word }
        var initialValue = words.size
        val checkRegex = Regex("^[A-Za-z].*\\s*[\u4E00-\u9F5A].*")
        val splitRegex = Regex("\\s*(?=[\u4E00-\u9F5A])")

        val list = reader.readLines().map {
            check(it.matches(checkRegex)) {
                "Invalid txt word book file , example \"hello 你好\""
            }
            it.split(splitRegex, 2)
        }

        return list.filter { !words.contains(it[0])}.map {
            val id = initialValue++.toLong()
            WordBookItem(
                id,
                it[0],
                Lang.AUTO,
                Lang.AUTO,
                null,
                it[1],
                emptySet<String>(),
                Date()
            )
        }

    }
}
```