### PR TITLE
use com.intellij.modules.python as a python dependency

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -60,7 +60,7 @@
     <depends optional="true" config-file="oc-doc.xml">com.intellij.modules.cidr.lang</depends>
     <depends optional="true" config-file="kotlin-doc.xml">org.jetbrains.kotlin</depends>
     <depends optional="true" config-file="go-doc.xml">org.jetbrains.plugins.go</depends>
-    <depends optional="true" config-file="python-doc.xml">Pythonid</depends>
+    <depends optional="true" config-file="python-doc.xml">com.intellij.modules.python</depends>
     <depends optional="true" config-file="dart-doc.xml">Dart</depends>
 
     <extensionPoints>


### PR DESCRIPTION
Pythonid is a Python plugin for IDEA, it is not present in PyCharm