### PR TITLE
Documentation actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ intellij {
     pluginName = 'TranslationPlugin'
     downloadSources = Boolean.valueOf(ideaSources)
     sandboxDirectory 'sandbox'
-    plugins "java", "org.jetbrains.kotlin", "Pythonid:201.8743.12", "Dart:201.8538.45", "org.jetbrains.plugins.go:201.8538.31.199"
+    plugins "java", "org.jetbrains.kotlin", "Pythonid:203.5981.155", "Dart:203.5981.155", "org.jetbrains.plugins.go:203.5981.155"
 }
 
 patchPluginXml {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 version=3.1
 #buildNumber=
 buildNumber=SNAPSHOT
-ideaVersion=IU-2020.1.4
-javaVersion=1.8
-javaTargetVersion=1.8
+ideaVersion=203.5981.155
+javaVersion=11
+javaTargetVersion=11
 kotlinLanguageVersion=1.4
 kotlinTargetVersion=1.3
 ideaSources=true
-customSinceBuild=201
+customSinceBuild=203
 customUntilBuild=
 kotlin.code.style=official
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/ToggleQuickDocTranslationAction.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/ToggleQuickDocTranslationAction.kt
@@ -13,13 +13,12 @@ import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowId
 import com.intellij.openapi.wm.ToolWindowManager
+import icons.Icons
 import org.jetbrains.concurrency.runAsync
 
-class ToggleQuickDocTranslationAction : ToggleAction(), HintManagerImpl.ActionToIgnore {
-
-    init {
-        templatePresentation.text = message("action.ToggleQuickDocTranslationAction.text")
-    }
+open class ToggleQuickDocTranslationAction :
+    ToggleAction({ message("settings.options.translate.documentation") } , Icons.Translation),
+    HintManagerImpl.ActionToIgnore {
 
     override fun update(e: AnActionEvent) {
         val project = e.project
@@ -82,6 +81,26 @@ class ToggleQuickDocTranslationAction : ToggleAction(), HintManagerImpl.ActionTo
                 component?.replaceText(newText, component.element)
             }
         }
+    }
+
+}
+
+private class ToggleQuickDocTranslationActionWithShortcut : ToggleQuickDocTranslationAction() {
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        if (project == null) {
+            e.presentation.isEnabled = false
+            return
+        }
+
+        val activeDocComponent = QuickDocUtil.getActiveDocComponent(project)
+        val docComponentExists = activeDocComponent != null
+        val hasSelection = TranslateQuickDocSelectionAction.quickDocHasSelection(e)
+
+        val toolWindowIsActiveIfShown =
+            ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.DOCUMENTATION)?.isActive ?: true
+
+        e.presentation.isEnabled = docComponentExists && !hasSelection && toolWindowIsActiveIfShown
     }
 
 }

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslateQuickDocSelectionAction.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslateQuickDocSelectionAction.kt
@@ -5,6 +5,7 @@ import cn.yiiguxing.plugin.translate.service.TranslationUIManager
 import cn.yiiguxing.plugin.translate.util.processBeforeTranslate
 import com.intellij.codeInsight.documentation.DocumentationManager
 import com.intellij.codeInsight.hint.HintManagerImpl
+import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
@@ -13,17 +14,18 @@ import com.intellij.openapi.project.Project
 /**
  * TranslateQuickDocAction
  */
-class TranslateQuickDocAction : AnAction(), DumbAware, HintManagerImpl.ActionToIgnore {
+class TranslateQuickDocSelectionAction : AnAction(), DumbAware, HintManagerImpl.ActionToIgnore {
 
     init {
         isEnabledInModalContext = true
-        templatePresentation.text = message("action.TranslateQuickDocAction.text")
+        templatePresentation.text = message("translate")
         templatePresentation.description = message("action.description.quickDoc")
     }
 
     override fun update(e: AnActionEvent) {
-        val selected = e.getData(DocumentationManager.SELECTED_QUICK_DOC_TEXT)
-        e.presentation.isEnabled = !selected.isNullOrBlank()
+        //don't show in toolbar, invoke via context menu or with keyboard shortcut
+        //to not clash with "Translate documentation" toggle
+        e.presentation.isEnabledAndVisible = quickDocHasSelection(e) && !e.isFromActionToolbar
     }
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -37,8 +39,11 @@ class TranslateQuickDocAction : AnAction(), DumbAware, HintManagerImpl.ActionToI
                 }
     }
 
-    private companion object {
-        fun Project.hideDocInfoHint() {
+    companion object {
+        fun quickDocHasSelection(e: AnActionEvent): Boolean =
+            !e.getData(DocumentationManager.SELECTED_QUICK_DOC_TEXT).isNullOrBlank()
+
+        private fun Project.hideDocInfoHint() {
             DocumentationManager.getInstance(this).docInfoHint?.cancel()
         }
     }

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslateQuickDocSelectionAction.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslateQuickDocSelectionAction.kt
@@ -33,7 +33,6 @@ class TranslateQuickDocSelectionAction : AnAction(), DumbAware, HintManagerImpl.
                 ?.processBeforeTranslate()
                 ?.let {
                     e.project.let { project ->
-                        project?.hideDocInfoHint()
                         TranslationUIManager.showDialog(project).translate(it)
                     }
                 }
@@ -42,9 +41,5 @@ class TranslateQuickDocSelectionAction : AnAction(), DumbAware, HintManagerImpl.
     companion object {
         fun quickDocHasSelection(e: AnActionEvent): Boolean =
             !e.getData(DocumentationManager.SELECTED_QUICK_DOC_TEXT).isNullOrBlank()
-
-        private fun Project.hideDocInfoHint() {
-            DocumentationManager.getInstance(this).docInfoHint?.cancel()
-        }
     }
 }

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslationPromoter.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslationPromoter.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import java.util.*
 
 class TranslationPromoter : ActionPromoter {
-    override fun promote(actions: MutableList<AnAction>, context: DataContext?): MutableList<AnAction> {
+    override fun promote(actions: MutableList<AnAction>, context: DataContext): MutableList<AnAction> {
         val newList: MutableList<AnAction> = ArrayList(actions)
         val comparator = Comparator.comparingInt { action: AnAction ->
             when (action) {

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/documentation/TranslateDocumentationActionProvider.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/documentation/TranslateDocumentationActionProvider.kt
@@ -1,0 +1,27 @@
+package cn.yiiguxing.plugin.translate.documentation
+
+import cn.yiiguxing.plugin.translate.action.ToggleQuickDocTranslationAction
+import cn.yiiguxing.plugin.translate.action.TranslateQuickDocSelectionAction
+import com.intellij.codeInsight.documentation.DocumentationActionProvider
+import com.intellij.codeInsight.documentation.DocumentationComponent
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.Separator
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiDocCommentBase
+
+class TranslateDocumentationActionProvider : DocumentationActionProvider {
+    override fun additionalActions(
+        editor: Editor,
+        docComment: PsiDocCommentBase,
+        renderedText: String
+    ): List<AnAction> {
+        return listOf(Separator(), TranslateRenderedDocAction(editor, docComment))
+    }
+
+
+    override fun additionalActions(component: DocumentationComponent): List<AnAction> {
+        return listOf(Separator(), TranslateQuickDocSelectionAction(), ToggleQuickDocTranslationAction())
+    }
+
+}
+

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/documentation/TranslateRenderedDocAction.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/documentation/TranslateRenderedDocAction.kt
@@ -1,0 +1,37 @@
+package cn.yiiguxing.plugin.translate.documentation
+
+import cn.yiiguxing.plugin.translate.message
+import com.intellij.codeInsight.documentation.render.DocRenderPassFactory
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.psi.PsiDocCommentBase
+import com.intellij.util.concurrency.AppExecutorUtil
+import icons.Icons
+
+internal class TranslateRenderedDocAction(val editor: Editor,
+                                          val docComment: PsiDocCommentBase
+) : ToggleAction({message("translate")}, Icons.Translation) {
+
+    override fun isSelected(event: AnActionEvent): Boolean {
+        return TranslatedDocComments.isTranslated(docComment)
+    }
+
+    override fun setSelected(event: AnActionEvent, value: Boolean) {
+        val file = docComment.containingFile ?: return
+
+        TranslatedDocComments.setTranslated(docComment, value)
+
+        val project = file.project
+        val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
+        ReadAction.nonBlocking<DocRenderPassFactory.Items> {
+            DocRenderPassFactory.calculateItemsToRender(editor, file)
+        }.finishOnUiThread(ModalityState.current()) {
+            DocRenderPassFactory.applyItemsToRender(editor, project, it, false)
+        }.submit(AppExecutorUtil.getAppExecutorService())
+    }
+
+}

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/documentation/TranslatedDocComments.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/documentation/TranslatedDocComments.kt
@@ -1,0 +1,51 @@
+package cn.yiiguxing.plugin.translate.documentation
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocCommentBase
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.util.concurrency.AppExecutorUtil
+import com.intellij.util.containers.ContainerUtil
+
+@Service
+internal class TranslatedDocComments: Disposable {
+
+    //use SmartPsiElementPointer to survive reparse
+    private val translatedDocs: MutableSet<SmartPsiElementPointer<PsiDocCommentBase>> = ContainerUtil.newConcurrentSet()
+
+    override fun dispose() {
+        translatedDocs.clear()
+    }
+
+    companion object {
+        fun isTranslated(docComment: PsiDocCommentBase): Boolean {
+            val translatedDocs = translatedDocs(docComment.project)
+            return translatedDocs.contains(SmartPointerManager.createPointer(docComment))
+        }
+
+        fun setTranslated(docComment: PsiDocCommentBase, value: Boolean) {
+            val translatedDocs = translatedDocs(docComment.project)
+
+            val pointer = SmartPointerManager.createPointer(docComment)
+
+            if (value) translatedDocs.add(pointer)
+            else translatedDocs.remove(pointer)
+
+            translatedDocs.scheduleCleanup()
+        }
+
+        private fun service(project: Project) = project.getService(TranslatedDocComments::class.java)
+
+        private fun translatedDocs(project: Project) = service(project).translatedDocs
+
+        private fun MutableSet<SmartPsiElementPointer<PsiDocCommentBase>>.scheduleCleanup() {
+            ReadAction.nonBlocking {
+                removeIf { it.element == null }
+            }.submit(AppExecutorUtil.getAppExecutorService())
+        }
+    }
+
+}

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/provider/TranslatingDocumentationProvider.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/provider/TranslatingDocumentationProvider.kt
@@ -2,6 +2,7 @@ package cn.yiiguxing.plugin.translate.provider
 
 import cn.yiiguxing.plugin.translate.Settings
 import cn.yiiguxing.plugin.translate.documentation.TranslateDocumentationTask
+import cn.yiiguxing.plugin.translate.documentation.TranslatedDocComments
 import cn.yiiguxing.plugin.translate.util.Application
 import cn.yiiguxing.plugin.translate.util.TranslateService
 import com.intellij.codeInsight.documentation.DocumentationManager
@@ -10,6 +11,7 @@ import com.intellij.lang.documentation.DocumentationProviderEx
 import com.intellij.lang.documentation.ExternalDocumentationProvider
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
+import com.intellij.psi.PsiDocCommentBase
 import com.intellij.psi.PsiElement
 
 /**
@@ -30,6 +32,19 @@ class TranslatingDocumentationProvider : DocumentationProviderEx(), ExternalDocu
             val originalDoc = providerFromElement.generateDoc(element, originalElement)
             translate(originalDoc, element?.language)
         }
+    }
+
+    @Suppress("UnstableApiUsage")
+    override fun generateRenderedDoc(docComment: PsiDocCommentBase): String? {
+        if (!TranslatedDocComments.isTranslated(docComment))
+            return null
+
+        val providerFromElement = DocumentationManager.getProviderFromElement(docComment)
+        val originalDoc = nullIfRecursive {
+            providerFromElement.generateRenderedDoc(docComment)
+        }
+
+        return translate(originalDoc, docComment.language)
     }
 
     override fun fetchExternalDocumentation(

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/LangComboBoxLink.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/LangComboBoxLink.kt
@@ -74,7 +74,7 @@ class LangComboBoxLink : LinkLabel<Lang>("Empty", AllIcons.General.ButtonDropTri
         }
 
     private object LangComboBoxLinkListener : LinkListener<Lang> {
-        override fun linkSelected(source: LinkLabel<*>, lang: Lang) {
+        override fun linkSelected(source: LinkLabel<Lang>, lang: Lang) {
             val langLink = source as LangComboBoxLink
             if (langLink.isPopupShowing) {
                 return

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/LangComboBoxUI.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/LangComboBoxUI.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.util.ui.JBInsets
 import com.intellij.util.ui.JBUI
-import sun.swing.DefaultLookup
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.Graphics
@@ -78,7 +77,7 @@ class LangComboBoxUI(
             val foregroundColor = if (isEnabled) {
                 foreground
             } else {
-                DefaultLookup.getColor(this, this@LangComboBoxUI, "ComboBox.disabledForeground")
+                UIManager.getColor("ComboBox.disabledForeground")
             }
 
             label.foreground = foregroundColor

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/StarButtons.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/StarButtons.kt
@@ -22,12 +22,11 @@ object StarButtons {
     }
 
     val listener: LinkListener<Translation> = object : LinkListener<Translation> {
-        override fun linkSelected(starLabel: LinkLabel<*>, translation: Translation?) {
+        override fun linkSelected(starLabel: LinkLabel<Translation>, translation: Translation?) {
             if (!WordBookService.isInitialized) {
                 WordBookToolWindowFactory.requireWordBook()
                 return
             }
-
             starLabel.isEnabled = false
             translation ?: return
             if (!WordBookService.canAddToWordbook(translation.original)) {

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/TranslationDialog.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/TranslationDialog.kt
@@ -214,7 +214,7 @@ class TranslationDialog(private val project: Project?) : TranslationDialogForm(p
     private fun ComboBox<Lang>.init(languages: List<Lang>) {
         andTransparent()
         foreground = JBColor(0x555555, 0xACACAC)
-        ui = LangComboBoxUI(this, SwingConstants.CENTER)
+        setUI(LangComboBoxUI(this, SwingConstants.CENTER))
         model = LanguageListModel.sorted(languages)
 
         fun ComboBox<Lang>.swap(old: Any?, new: Any?) {

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/wordbook/WordBookImportExport.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/wordbook/WordBookImportExport.kt
@@ -76,7 +76,7 @@ fun WordBookExporter.export(project: Project?, words: List<WordBookItem>) {
             ),
             project
         )
-        .save(null, "wordbook.$extension") ?: return
+        .save("wordbook.$extension") ?: return
 
     val targetFile = targetFileWrapper.getVirtualFile(true)
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -56,7 +56,7 @@
     ]]></change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="201.8743"/>
+    <idea-version since-build="203.5981.155"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -125,6 +125,7 @@
         <postStartupActivity implementation="cn.yiiguxing.plugin.translate.update.UpdateManager"/>
         <postStartupActivity implementation="cn.yiiguxing.plugin.translate.activity.WordOfTheDayStartupActivity"/>
         <actionPromoter implementation="cn.yiiguxing.plugin.translate.action.TranslationPromoter"/>
+        <documentationActionProvider implementation="cn.yiiguxing.plugin.translate.documentation.TranslateDocumentationActionProvider"/>
     </extensions>
 
     <actions>
@@ -162,7 +163,7 @@
         <action id="$ExclusiveTranslateAction"
                 class="cn.yiiguxing.plugin.translate.action.ExclusiveTranslateAction"/>
         <action id="$TranslateQuickDocAction"
-                class="cn.yiiguxing.plugin.translate.action.TranslateQuickDocAction"
+                class="cn.yiiguxing.plugin.translate.action.TranslateQuickDocSelectionAction"
                 use-shortcut-of="$EditorTranslateAction"/>
         <action id="$TranslateTextComponent"
                 class="cn.yiiguxing.plugin.translate.action.TranslateTextComponentAction"
@@ -180,8 +181,8 @@
             <add-to-group group-id="HelpMenu" anchor="after" relative-to-action="WhatsNewAction"/>
         </action>
 
-        <action id="ToggleQuickDocTranslationAction"
-                class="cn.yiiguxing.plugin.translate.action.ToggleQuickDocTranslationAction"
+        <action id="ToggleQuickDocTranslationActionWithShortcut"
+                class="cn.yiiguxing.plugin.translate.action.ToggleQuickDocTranslationActionWithShortcut"
                 use-shortcut-of="$EditorTranslateAction">
         </action>
 


### PR DESCRIPTION
Adds more actions to translate documentations, both in quick documentation and in-editor documentation inlays. This requires new API that is available only in 2020.3.

![image](https://user-images.githubusercontent.com/3604749/104291877-2a525600-54cd-11eb-8112-e74a61595d49.png)
![image](https://user-images.githubusercontent.com/3604749/104291898-3211fa80-54cd-11eb-9dd8-6e49524023d7.png)

In Quick Documentation popup:
![image](https://user-images.githubusercontent.com/3604749/104292014-55d54080-54cd-11eb-91fb-135514cf12d9.png)

If toolbar is enabled:
![image](https://user-images.githubusercontent.com/3604749/104292232-9f259000-54cd-11eb-88af-ea2c27e68ea0.png)
