### PR TITLE
Cleaner UI

### DIFF
--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/ChooseTranslatorAction.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/ChooseTranslatorAction.kt
@@ -27,6 +27,8 @@ class ChooseTranslatorAction : ComboBoxAction(), DumbAware {
     }
 
     override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = TranslatorAction.availableActions().size > 1
+
         TranslateService.translator.let {
             e.presentation.text = it.name
             e.presentation.icon = it.icon
@@ -66,7 +68,7 @@ class ChooseTranslatorAction : ComboBoxAction(), DumbAware {
     override fun getPreselectCondition(): Condition<AnAction> = TranslatorAction.PRESELECT_CONDITION
 
     override fun createPopupActionGroup(button: JComponent)
-            : DefaultActionGroup = DefaultActionGroup(TranslatorAction.ACTIONS)
+            : DefaultActionGroup = DefaultActionGroup(TranslatorAction.availableActions())
 
     override fun createComboBoxButton(presentation: Presentation): ComboBoxButton =
         object : ComboBoxButton(presentation) {

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslatorAction.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslatorAction.kt
@@ -13,12 +13,16 @@ import com.intellij.openapi.util.Condition
 class TranslatorAction(private val translator: TranslationEngine) :
     DumbAwareAction(translator.translatorName, null, translator.icon) {
 
+    fun isAvailable(): Boolean = translator.isConfigured() || Settings.translator == translator
+
     override fun actionPerformed(e: AnActionEvent) {
         Settings.translator = translator
     }
 
     companion object {
-        val ACTIONS: List<TranslatorAction> = TranslationEngine.values().toList().map { TranslatorAction(it) }
+        private val ACTIONS: List<TranslatorAction> = TranslationEngine.values().toList().map { TranslatorAction(it) }
+
+        fun availableActions(): List<TranslatorAction> = ACTIONS.filter { it.isAvailable() }
 
         val PRESELECT_CONDITION: Condition<AnAction> = Condition { action ->
             (action as? TranslatorAction)?.translator == Settings.translator

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslatorActionGroup.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslatorActionGroup.kt
@@ -9,8 +9,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
  */
 class TranslatorActionGroup : ActionGroup() {
 
-    private val translatorActions: Array<AnAction> = TranslatorAction.ACTIONS.toTypedArray()
-
-    override fun getChildren(e: AnActionEvent?): Array<AnAction> = translatorActions
-
+    override fun getChildren(e: AnActionEvent?): Array<AnAction> =
+        TranslatorAction.availableActions().toTypedArray()
 }

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/settings/SettingsPanel.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/settings/SettingsPanel.kt
@@ -12,6 +12,7 @@ import cn.yiiguxing.plugin.translate.util.SelectionMode
 import cn.yiiguxing.plugin.translate.util.executeOnPooledThread
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.CollectionComboBoxModel
 import com.intellij.ui.EditorTextField
@@ -150,6 +151,7 @@ class SettingsPanel(val settings: Settings, val appStorage: AppStorage) : Settin
 
             val settings = settings
             return settings.translator != translationEngineComboBox.selected
+                    || !settings.translator.isConfigured()
                     || settings.translator.primaryLanguage != primaryLanguageComboBox.selected
                     || settings.targetLanguageSelection != targetLangSelectionComboBox.selected
                     || settings.googleTranslateSettings.useTranslateGoogleCom != useTranslateGoogleComCheckBox.isSelected
@@ -184,7 +186,11 @@ class SettingsPanel(val settings: Settings, val appStorage: AppStorage) : Settin
 
         @Suppress("Duplicates")
         with(settings) {
-            translator = translationEngineComboBox.selected ?: translator
+            val selectedTranslator = translationEngineComboBox.selected ?: translator
+            if (!selectedTranslator.isConfigured()) {
+                throw ConfigurationException(message("settings.translator.requires.configuration", selectedTranslator.translatorName))
+            }
+            translator = selectedTranslator
             translator.primaryLanguage = primaryLanguageComboBox.selected ?: translator.primaryLanguage
             targetLanguageSelection = targetLangSelectionComboBox.selected ?: TargetLanguageSelection.DEFAULT
             googleTranslateSettings.useTranslateGoogleCom = useTranslateGoogleComCheckBox.isSelected

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/settings/TranslationEngine.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/settings/TranslationEngine.kt
@@ -1,12 +1,13 @@
 package cn.yiiguxing.plugin.translate.ui.settings
 
+import cn.yiiguxing.plugin.translate.AppKeySettings
 import cn.yiiguxing.plugin.translate.BAIDU_FANYI_URL
-import cn.yiiguxing.plugin.translate.Settings
 import cn.yiiguxing.plugin.translate.YOUDAO_AI_URL
 import cn.yiiguxing.plugin.translate.message
 import cn.yiiguxing.plugin.translate.trans.*
 import cn.yiiguxing.plugin.translate.ui.form.AppKeySettingsDialog
 import cn.yiiguxing.plugin.translate.ui.form.AppKeySettingsPanel
+import cn.yiiguxing.plugin.translate.util.Settings
 import com.intellij.openapi.util.IconLoader
 import icons.Icons
 import javax.swing.Icon
@@ -26,16 +27,16 @@ enum class TranslationEngine(
     var primaryLanguage: Lang
         get() {
             return when (this) {
-                GOOGLE -> Settings.instance.googleTranslateSettings.primaryLanguage
-                YOUDAO -> Settings.instance.youdaoTranslateSettings.primaryLanguage
-                BAIDU -> Settings.instance.baiduTranslateSettings.primaryLanguage
+                GOOGLE -> Settings.googleTranslateSettings.primaryLanguage
+                YOUDAO -> Settings.youdaoTranslateSettings.primaryLanguage
+                BAIDU -> Settings.baiduTranslateSettings.primaryLanguage
             }
         }
         set(value) {
             when (this) {
-                GOOGLE -> Settings.instance.googleTranslateSettings.primaryLanguage = value
-                YOUDAO -> Settings.instance.youdaoTranslateSettings.primaryLanguage = value
-                BAIDU -> Settings.instance.baiduTranslateSettings.primaryLanguage = value
+                GOOGLE -> Settings.googleTranslateSettings.primaryLanguage = value
+                YOUDAO -> Settings.youdaoTranslateSettings.primaryLanguage = value
+                BAIDU -> Settings.baiduTranslateSettings.primaryLanguage = value
             }
         }
 
@@ -50,6 +51,17 @@ enum class TranslationEngine(
 
     fun supportedTargetLanguages(): List<Lang> = translator.supportedTargetLanguages
 
+    fun isConfigured(): Boolean {
+        return when (this) {
+            GOOGLE -> true
+            YOUDAO -> isConfigured(Settings.youdaoTranslateSettings)
+            BAIDU -> isConfigured(Settings.baiduTranslateSettings)
+        }
+    }
+
+    private fun isConfigured(settings: AppKeySettings) =
+        settings.appId.isNotEmpty() && settings.getAppKey().isNotEmpty()
+
     fun showConfigurationDialog(): Boolean {
         return when (this) {
             YOUDAO -> AppKeySettingsDialog(
@@ -57,7 +69,7 @@ enum class TranslationEngine(
                 AppKeySettingsPanel(
                     IconLoader.getIcon("/image/youdao_translate_logo.png"),
                     YOUDAO_AI_URL,
-                    Settings.instance.youdaoTranslateSettings
+                    Settings.youdaoTranslateSettings
                 )
             ).showAndGet()
             BAIDU -> AppKeySettingsDialog(
@@ -65,7 +77,7 @@ enum class TranslationEngine(
                 AppKeySettingsPanel(
                     IconLoader.getIcon("/image/baidu_translate_logo.png"),
                     BAIDU_FANYI_URL,
-                    Settings.instance.baiduTranslateSettings
+                    Settings.baiduTranslateSettings
                 )
             ).showAndGet()
             else -> true

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/wordbook/WordBookToolWindowFactory.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/wordbook/WordBookToolWindowFactory.kt
@@ -1,5 +1,7 @@
 package cn.yiiguxing.plugin.translate.wordbook
 
+import cn.yiiguxing.plugin.translate.service.TranslationUIManager
+import cn.yiiguxing.plugin.translate.util.Application
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
@@ -14,7 +16,27 @@ class WordBookToolWindowFactory : ToolWindowFactory, DumbAware {
         WordBookView.instance.setup(project, toolWindow)
     }
 
-    companion object{
+    override fun init(toolWindow: ToolWindow) {
+        Application.messageBus
+            .connect(TranslationUIManager.disposable())
+            .subscribe(WordBookListener.TOPIC, object : WordBookListener {
+
+                override fun onWordAdded(service: WordBookService, wordBookItem: WordBookItem) {
+                    toolWindow.isAvailable = true
+                }
+
+                override fun onWordRemoved(service: WordBookService, id: Long) {
+                    if (service.getWords().isEmpty()) {
+                        toolWindow.isAvailable = false
+                    }
+                }
+            })
+
+    }
+
+    override fun shouldBeAvailable(project: Project): Boolean = WordBookService.instance.getWords().isNotEmpty()
+
+    companion object {
         const val TOOL_WINDOW_ID = "Word Book"
     }
 

--- a/src/main/resources/messages/TranslationBundle.properties
+++ b/src/main/resources/messages/TranslationBundle.properties
@@ -17,6 +17,7 @@ settings.panel.title.cacheAndHistory=Cache and History
 settings.panel.title.other=Other
 settings.youdao.title=Youdao Settings
 settings.baidu.title=Baidu Settings
+settings.translator.requires.configuration={0} requires configuration
 settings.check.regex.title=Check Regex
 settings.label.translation.engine=Translation engine:
 settings.label.targetLanguage=Target language:


### PR DESCRIPTION
We at JetBrains always try to find a balance between discoverability of a feature and a clean and simple UI. In particular that usually means not showing feature-related UI elements in contexts when it is not likely to be used. Changes in this PR hide Word Book toolwindow and Translator widget when they are not useful, so I think it doesn’t break any existing user habits.

But I also have another suggestion in the same direction. I think it would be better to show “Translate” and “Translate and Replace” actions in the context menu only when some text is selected in the editor. Auto-selection will still work if an action is invoked with a shortcut, and selecting text is not too difficult when your hand is already on a trackpad or a mouse. Otherwise it distracts users if they use right click to find some other action. I may create a separate PR with the corresponding changes.

![image](https://user-images.githubusercontent.com/3604749/108598588-8303f100-739f-11eb-8b10-3a5285d38145.png)

