### PR TITLE
hide "Translate" and "Translate and Replace" actions from context menu

### DIFF
--- a/src/main/java/cn/yiiguxing/plugin/translate/ui/form/SettingsForm.kt
+++ b/src/main/java/cn/yiiguxing/plugin/translate/ui/form/SettingsForm.kt
@@ -94,8 +94,6 @@ abstract class SettingsForm {
     protected val phoneticFontPreview: JLabel = JLabel(PHONETIC_CHARACTERS)
     protected val restoreDefaultButton = JButton(message("settings.button.restore.default.fonts"))
 
-    protected val translateDocumentationCheckBox: JBCheckBox =
-        JBCheckBox(message("settings.options.translate.documentation"))
     protected val foldOriginalCheckBox: JBCheckBox = JBCheckBox(message("settings.options.foldOriginal"))
 
     protected val ttsSourceComboBox: ComboBox<TTSSource> =
@@ -124,6 +122,12 @@ abstract class SettingsForm {
 
     protected val cacheSizeLabel: JLabel = JLabel("0KB")
     protected val clearCacheButton: JButton = JButton(message("settings.cache.button.clear"))
+
+    protected val translateDocumentationCheckBox: JBCheckBox =
+        JBCheckBox(message("settings.options.translate.documentation"))
+
+    protected val showActionsInContextMenuOnlyWithSelectionCheckbox: JBCheckBox =
+        JBCheckBox(message("settings.options.show.actions.only.with.selection"))
 
     protected val supportLinkLabel: LinkLabel<*> = LinkLabel<Any>(message("support.or.donate"), Icons.Support).apply {
         border = JBUI.Borders.empty(20, 0, 0, 0)
@@ -229,6 +233,7 @@ abstract class SettingsForm {
 
         val otherPanel = titledPanel(message("settings.panel.title.other")) {
             add(translateDocumentationCheckBox, wrap())
+            add(showActionsInContextMenuOnlyWithSelectionCheckbox, wrap())
         }
 
         wholePanel.addVertically(

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/Settings.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/Settings.kt
@@ -146,6 +146,8 @@ class Settings : PersistentStateComponent<Settings> {
 
     var translateDocumentation: Boolean = false
 
+    var showActionsInContextMenuOnlyWithSelection: Boolean = true
+
     var primaryFontPreviewText = message("settings.font.default.preview.text")
 
     override fun getState(): Settings = this

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/EditorTranslateAction.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/EditorTranslateAction.kt
@@ -2,6 +2,7 @@ package cn.yiiguxing.plugin.translate.action
 
 import cn.yiiguxing.plugin.translate.message
 import cn.yiiguxing.plugin.translate.util.Settings
+import com.intellij.openapi.actionSystem.AnActionEvent
 
 /**
  * 翻译动作，自动从最大范围内取词，优先选择
@@ -12,6 +13,10 @@ class EditorTranslateAction : TranslateAction(true) {
         isEnabledInModalContext = true
         templatePresentation.text = message("action.EditorTranslateAction.text")
         templatePresentation.description = message("action.EditorTranslateAction.description")
+    }
+
+    override fun onUpdate(e: AnActionEvent): Boolean {
+        return (hasEditorSelection(e) || mayTranslateWithNoSelection(e)) && super.onUpdate(e)
     }
 
     override val selectionMode

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslateAndReplaceAction.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/TranslateAndReplaceAction.kt
@@ -74,7 +74,7 @@ class TranslateAndReplaceAction : AutoSelectAction(true, NON_WHITESPACE_CONDITIO
         if (selectionModel.hasSelection()) {
             return selectionModel.selectedText?.any(JAVA_IDENTIFIER_PART_CONDITION) ?: false
         }
-        return super.onUpdate(e)
+        return mayTranslateWithNoSelection(e) && super.onUpdate(e)
     }
 
     override fun onActionPerformed(event: AnActionEvent, editor: Editor, selectionRange: TextRange) {

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/action/actions.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/action/actions.kt
@@ -1,0 +1,18 @@
+package cn.yiiguxing.plugin.translate.action
+
+import cn.yiiguxing.plugin.translate.util.Settings
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.editor.Editor
+
+val AnActionEvent.editor: Editor? get() = CommonDataKeys.EDITOR.getData(dataContext)
+
+fun hasEditorSelection(e: AnActionEvent): Boolean = e.editor?.selectionModel?.hasSelection() ?: false
+
+fun mayTranslateWithNoSelection(e: AnActionEvent): Boolean {
+    val isContextMenu = e.place == ActionPlaces.EDITOR_POPUP
+    val hideWithNoSelection = isContextMenu && Settings.showActionsInContextMenuOnlyWithSelection
+
+    return !hideWithNoSelection
+}

--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/settings/SettingsPanel.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/ui/settings/SettingsPanel.kt
@@ -172,6 +172,7 @@ class SettingsPanel(val settings: Settings, val appStorage: AppStorage) : Settin
                     || settings.showWordsOnStartup != showWordsOnStartupCheckBox.isSelected
                     || settings.showExplanation != showExplanationCheckBox.isSelected
                     || settings.translateDocumentation != translateDocumentationCheckBox.isSelected
+                    || settings.showActionsInContextMenuOnlyWithSelection != showActionsInContextMenuOnlyWithSelectionCheckbox.isSelected
                     || appStorage.maxHistorySize != getMaxHistorySize()
         }
 
@@ -209,6 +210,7 @@ class SettingsPanel(val settings: Settings, val appStorage: AppStorage) : Settin
             showWordsOnStartup = showWordsOnStartupCheckBox.isSelected
             showExplanation = showExplanationCheckBox.isSelected
             translateDocumentation = translateDocumentationCheckBox.isSelected
+            showActionsInContextMenuOnlyWithSelection = showActionsInContextMenuOnlyWithSelectionCheckbox.isSelected
             takeWordWhenDialogOpens = takeWordCheckBox.isSelected
 
             if (validRegExp) {
@@ -242,6 +244,7 @@ class SettingsPanel(val settings: Settings, val appStorage: AppStorage) : Settin
         takeNearestWordCheckBox.isSelected = settings.autoSelectionMode == SelectionMode.EXCLUSIVE
         ttsSourceComboBox.selected = settings.ttsSource
         translateDocumentationCheckBox.isSelected = settings.translateDocumentation
+        showActionsInContextMenuOnlyWithSelectionCheckbox.isSelected = settings.showActionsInContextMenuOnlyWithSelection
         takeWordCheckBox.isSelected = settings.takeWordWhenDialogOpens
     }
 

--- a/src/main/resources/messages/TranslationBundle.properties
+++ b/src/main/resources/messages/TranslationBundle.properties
@@ -39,6 +39,7 @@ settings.cache.button.clear=Clear
 settings.options.take.single.word=Take nearest single word
 settings.options.take.word.when.translation.dialog.opens=Take word when translation dialog opens
 settings.options.translate.documentation=Translate documentation
+settings.options.show.actions.only.with.selection=Show translation actions on right click only when text is selected
 settings.options.foldOriginal=Fold original text
 settings.options.keepFormatting=Keep content formatting
 settings.options.autoPlayTTS=Play Text to Speech automatically:


### PR DESCRIPTION
As suggested in https://github.com/YiiGuxing/TranslationPlugin/pull/668
A setting is added to restore old behaviour.