### PR TITLE
open documentation pages based on language to support custom locales

### DIFF
--- a/src/main/kotlin/cn/yiiguxing/plugin/translate/update/UpdateManager.kt
+++ b/src/main/kotlin/cn/yiiguxing/plugin/translate/update/UpdateManager.kt
@@ -136,17 +136,15 @@ class UpdateManager : BaseStartupActivity(), DumbAware {
                 Locale.CHINA,
                 Locale.CHINESE,
                 Locale.SIMPLIFIED_CHINESE -> BASE_URL_GITEE
-                else -> BASE_URL_GITHUB
+                else ->
+                    if (locale.country == Locale.CHINA.country) BASE_URL_GITEE
+                    else BASE_URL_GITHUB
             }
-            val langPath = when (locale) {
-                Locale.CHINA,
-                Locale.CHINESE,
-                Locale.SIMPLIFIED_CHINESE -> ""
-                Locale.JAPAN,
-                Locale.JAPANESE,
-                Locale.KOREA,
-                Locale.KOREAN -> "/${locale.language}"
-                else -> "/en"
+            val langPath = when (locale.language) {
+                Locale.CHINESE.language  -> ""
+                Locale.JAPANESE.language -> "/ja"
+                Locale.KOREAN.language   -> "/ko"
+                else                     -> "/en"
             }
 
             return "$baseUrl$langPath"


### PR DESCRIPTION
It was suggested by our QA because Translation plugin settings and What's New page were different. 